### PR TITLE
Feature/tls installation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,9 +25,18 @@ lsblk
 ## Docker
 
 ```shell
-sudo apt install docker.io
-sudo systemctl start docker
-sudo systemctl enable docker
+sudo apt-get update
+sudo apt-get install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
 ```
 
 ## Kfctl
@@ -53,6 +62,9 @@ sudo apt-get install kubeadm=1.15.7-00 kubelet=1.15.7-00 kubectl=1.15.7-00
 ```shell
 sudo sysctl net.bridge.bridge-nf-call-iptables=1
 sudo kubeadm init
+
+sudo sed -i '/^    - --service-account-key-file.*/a \ \ \ \ - --service-account-issuer=kubernetes.default.svc' /etc/kubernetes/manifests/kube-apiserver.yaml
+sudo sed -i '/^    - --service-account-key-file.*/a \ \ \ \ - --service-account-signing-key-file=/etc/kubernetes/pki/sa.key' /etc/kubernetes/manifests/kube-apiserver.yaml
 
 rm -rf $HOME/.kube
 mkdir -p $HOME/.kube

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -37,6 +37,8 @@ sudo add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
 ## Kfctl

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As of today, Kubernetes versions 1.14 and 1.15 are supported.
 
 Ensure that you have a [Kubernetes Cluster](https://kubernetes.io/docs/setup/), [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl), and [kfctl](https://www.kubeflow.org/docs/started/getting-started/#installing-command-line-tools) configured for running commands against the Kubernetes cluster.
 
-## Install PlatIAgro
+## Install PlatIAgro (HTTP)
 
 ```shell
 export KF_NAME=platiagro
@@ -31,7 +31,21 @@ cd ${KF_DIR}
 kfctl apply -V -f ${CONFIG_URI}
 ```
 
-Then visit: http://localhost:31380/
+Then visit: http://<LOAD-BALANCER-IP>/
+
+## Install PlatIAgro (HTTPS)
+
+```shell
+export KF_NAME=platiagro
+export BASE_DIR=$(pwd)
+export KF_DIR=${BASE_DIR}/${KF_NAME}
+export CONFIG_URI="https://raw.githubusercontent.com/platiagro/manifests/v0.1.0-kubeflow-v1.0-branch/kfdef/kfctl_platiagro_tls.v0.1.0.yaml"
+mkdir -p ${KF_DIR}
+cd ${KF_DIR}
+kfctl apply -V -f ${CONFIG_URI}
+```
+
+Then visit: https://<LOAD-BALANCER-IP>/
 
 ## Delete PlatIAgro
 


### PR DESCRIPTION
Prepare cluster for Istio TLS …
For kubeadm created clusters, two options must be added to
/etc/kubernetes/manifests/kube-apiserver.yaml

"service-account-issuer": "kubernetes.default.svc"
"service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
For further details, see:
https://www.kubeflow.org/docs/started/k8s/kfctl-istio-dex/#notes-on-the-configuration-file
Adds instructions to install platiagro under HTTPS …
It uses a different manifest: kfctl_platiagro_tls.v0.1.0.yaml
That creates a self-signed certificate, and changes istio-gateway
to use HTTPS (and the certificate).